### PR TITLE
lchat: flush earlier to make sure the initial prompt is displayed

### DIFF
--- a/lchat.c
+++ b/lchat.c
@@ -335,6 +335,9 @@ main(int argc, char *argv[])
 	fputs(prompt, stdout);
 
 	for (;;) {
+		if (fflush(stdout) == EOF)
+			err(EXIT_FAILURE, "fflush");
+
 		errno = 0;
 		if (poll(pfd, nfds, INFTIM) == -1 && errno != EINTR)
 			err(EXIT_FAILURE, "poll");
@@ -445,9 +448,6 @@ main(int argc, char *argv[])
 			if (sl->rcur + prompt_len > 0)
 				printf("\033[%zuC", sl->rcur + prompt_len);
 		}
-
-		if (fflush(stdout) == EOF)
-			err(EXIT_FAILURE, "fflush");
 	}
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The first fflush(3) occurs when the first character is read. In case we
need to wait a bit longer for this to happen, the initial prompt isn't
printed immediately and the program looks like it hung up.