### PR TITLE
slackline: fix reallocation memory issue

### DIFF
--- a/slackline.c
+++ b/slackline.c
@@ -254,6 +254,8 @@ compose:
 		if ((nbuf = realloc(sl->buf, sl->bufsize * 2)) == NULL)
 			return -1;
 
+		sl->ptr = nbuf + (sl->ptr - sl->buf);
+		sl->last = nbuf + (sl->last - sl->buf);
 		sl->buf = nbuf;
 		sl->bufsize *= 2;
 	}


### PR DESCRIPTION
It is necessary to update `sl->ptr` and `sl->last` pointers appropriately after reallocation otherwise backspacing or deleting can work in wrong memory area.