### PR TITLE
slackline: implement sl_move() to handle cursor movement

### DIFF
--- a/slackline.c
+++ b/slackline.c
@@ -124,18 +124,14 @@ sl_move(struct slackline *sl, enum direction dir)
 		return;
 	case END:
 		sl->rcur = sl->rlen;
-		sl->bcur = sl_postobyte(sl, sl->rcur);
-		sl->ptr = sl->buf + sl->bcur;
-		return;
+		break;
 	case RIGHT:
 		if (sl->rcur < sl->rlen)
 			sl->rcur++;
 		break;
 	case LEFT:
-		if (sl->rcur > 0) {
+		if (sl->rcur > 0)
 			sl->rcur--;
-			sl->bcur = sl_postobyte(sl, sl->rcur);
-		}
 		break;
 	}
 


### PR DESCRIPTION
The reasoning behind this is mainly to avoid code duplication when implementing modes. Additionally, I think it improves readability since a lot of the pointer arithmetic is moved to a function.

Are you fine with the `enum` and it's name?