### PR TITLE
slackline: add (another) vt-sequence for <End>

### DIFF
--- a/slackline.c
+++ b/slackline.c
@@ -200,6 +200,7 @@ sl_keystroke(struct slackline *sl, int key)
 			case '7':
 				sl_move(sl, HOME);
 				break;
+			case '4':
 			case '8':
 				sl_move(sl, END);
 				break;


### PR DESCRIPTION
Some terminal emulators, like st, emit ^[[4~ when the <End> key is pressed. This is a vt-sequence and analogue to the xterm-sequence ^[[F.